### PR TITLE
Extra functionality of stabilizer backend

### DIFF
--- a/tests/auto/stabilizerStates/test_stabilizerStates.py
+++ b/tests/auto/stabilizerStates/test_stabilizerStates.py
@@ -2,7 +2,7 @@ import unittest
 import numpy as np
 import networkx as nx
 
-from SimulaQron.toolbox.stabilizerStates import StabilizerState
+from toolbox.stabilizerStates import StabilizerState
 
 
 class TestStabilizerStates(unittest.TestCase):

--- a/tests/auto/stabilizerStates/test_stabilizerStates.py
+++ b/tests/auto/stabilizerStates/test_stabilizerStates.py
@@ -351,8 +351,9 @@ class TestStabilizerStates(unittest.TestCase):
         GHZ.apply_H(0)
         for i in range(1, n):
             GHZ.apply_CNOT(0, i)
-        GHZ_graph = GHZ.find_SQC_equiv_graph_state()
+        GHZ_graph,operations = GHZ.find_SQC_equiv_graph_state(return_operations=True)
         self.assertTrue(GHZ_graph,nx.star_graph(n-1))
+        self.assertTrue(operations == [('H', i) for i in range(1,n)])
 
 
 

--- a/tests/auto/stabilizerStates/test_stabilizerStates.py
+++ b/tests/auto/stabilizerStates/test_stabilizerStates.py
@@ -332,6 +332,30 @@ class TestStabilizerStates(unittest.TestCase):
             outcomes = [GHZ.measure(0) for _ in range(n)]
             self.assertNotIn(False, [outcomes[0] == outcomes[i] for i in range(1, n)])
 
+    def test_going_to_graph(self):
+        one_Bell_pair = StabilizerState(["-1XX", "+1ZZ"])
+        G = nx.Graph()
+        G.add_edge(0,1)
+        one_Bell_pair_graph = one_Bell_pair.find_SQC_equiv_graph_state()
+        self.assertTrue(G,one_Bell_pair_graph)
+
+        two_EPR_pairs = StabilizerState([[1,0,0,1,0,0,0,0],[0,1,1,0,0,0,0,0],
+                                        [0,0,0,0,1,0,0,1],[0,0,0,0,0,1,1,0]])
+        G.remove_edge(0,1)
+        G.add_edges_from([(0,3),(1,2)])
+        two_EPR_pairs_graph = two_EPR_pairs.find_SQC_equiv_graph_state()
+        self.assertTrue(G,two_EPR_pairs_graph)
+
+        n = 5
+        GHZ = StabilizerState(n)
+        GHZ.apply_H(0)
+        for i in range(1, n):
+            GHZ.apply_CNOT(0, i)
+        GHZ_graph = GHZ.find_SQC_equiv_graph_state()
+        self.assertTrue(GHZ_graph,nx.star_graph(n-1))
+
+
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/auto/stabilizerStates/test_stabilizerStates.py
+++ b/tests/auto/stabilizerStates/test_stabilizerStates.py
@@ -160,6 +160,27 @@ class TestStabilizerStates(unittest.TestCase):
         self.assertEqual(s3.num_qubits, 2)
         self.assertTrue(s3 == s4)
 
+    def test_Pauli_phase_tracking(self):
+        S = StabilizerState()
+        self.assertFalse(S.Pauli_phase_tracking([False,False],[False,False]))
+        self.assertFalse(S.Pauli_phase_tracking([True,True],[True,True]))
+        self.assertFalse(S.Pauli_phase_tracking([True,False],[True,False]))
+        self.assertFalse(S.Pauli_phase_tracking([False,True],[False,True]))
+
+        self.assertTrue(S.Pauli_phase_tracking([True,True],[True,False]))
+        self.assertTrue(S.Pauli_phase_tracking([False,True],[True,True]))
+        self.assertTrue(S.Pauli_phase_tracking([True,False],[False,True]))
+
+        self.assertEqual(S.Pauli_phase_tracking([True,False],[True,True]),
+                        S.Pauli_phase_tracking([True,True],[False,True]))
+        self.assertEqual(S.Pauli_phase_tracking([False,True],[True,False]),
+                        S.Pauli_phase_tracking([True,True],[False,True]))
+
+    def test_gaussian_elimination(self):
+        S = StabilizerState(["XZZ","YIX","IXX"])
+        S.put_in_standard_form()
+        self.assertTrue(np.array_equal(S.to_array(),StabilizerState(["+1XZZ","-1ZYZ","-1ZZY"]).to_array()))
+
     def test_apply_Pauli(self):
         s1 = StabilizerState([[0, 1]])
         s2 = StabilizerState([[0, 1, 1]])

--- a/toolbox/stabilizerStates.py
+++ b/toolbox/stabilizerStates.py
@@ -594,7 +594,7 @@ class StabilizerState:
         #then swap back (first the columns, then the rows to keep identity on the X-part)
         Spp_mat = Spp_mat[:,A[:2*n]]
         Spp_mat = Spp_mat[A[:n],:]
-        Spp = StabilizerState(np.c_[Spp_mat,phase_list])
+        Spp = StabilizerState(np.c_[Spp_mat,[phase_list[i] for i in A[:n]]])
 
         #Spp is now a graph state with possible self loops. To remove these,
         #do an S on every qubit with a self loop

--- a/toolbox/stabilizerStates.py
+++ b/toolbox/stabilizerStates.py
@@ -10,7 +10,7 @@
 import numpy as np
 import networkx as nx
 from scipy.linalg import block_diag
-from random import randint
+from random import randint,sample,choice
 from functools import partial
 
 
@@ -596,23 +596,72 @@ class StabilizerState:
                 pass
         return outcome
 
-    def do_random_SQC(self,j=None):
-        i = randint(0,6)
-        if j==None:
-            j = randint(0,self.num_qubits-1)
+    def random_Clifford_operations(self,position=None,seq_oper=None,inplace=True,hermitian=False,multi_qubits=None,return_seq=False):
+        if position is None:
+            position = list(range(self.num_qubits))
+        elif isinstance(position, int):
+            position = [position]
+        elif isinstance(position, list):
+            pass
 
-        if i==0:
-            self.apply_X(j)
-        elif i==1:
-            self.apply_Y(j)
-        elif i==2:
-            self.apply_Z(j)
-        elif i==3:
-            self.apply_H(j)
-        elif i==4:
-            self.apply_K(j)
-        elif i==5:
-            self.apply_S(j)
+        if multi_qubits is None:
+            if len(position)==1:
+                multi_qubits = False
+            else:
+                multi_qubits = True
+
+        if seq_oper is None:
+            seq_oper=[]
+            oper_list = ['X','Y','Z','S','H','K']
+            oper_list_2 = ['CZ','CNOT']
+            for _ in range(len(position)*3):
+                if choice([0,0,0,0,1]) and multi_qubits:
+                    seq_oper.append((choice(oper_list_2),tuple(sample(position,2))))
+                    pass
+                else:
+                    seq_oper.append((choice(oper_list),choice(position)))
+
+        if inplace:
+            if hermitian: seq_oper = seq_oper[::-1]
+            for oper,qubits in seq_oper:
+                if oper == 'CZ':
+                    self.apply_CZ(qubits[0],qubits[1])
+                elif oper == 'CNOT':
+                    self.apply_CNOT(qubits[0],qubits[1])
+                elif oper == 'X':
+                    self.apply_X(qubits)
+                elif oper == 'Y':
+                    self.apply_Y(qubits)
+                elif oper == 'Z':
+                    self.apply_Z(qubits)
+                elif oper == 'S':
+                    if not hermitian:
+                        self.apply_S(qubits)
+                    else:
+                        self.apply_S(qubits)
+                        self.apply_Z(qubits)
+                elif oper == 'H':
+                    self.apply_H(qubits)
+                elif oper == 'K':
+                    self.apply_K(qubits)
+                elif oper == 'LC_N':
+                    if not hermitian:
+                        self.apply_sqrt_IZ(qubits)
+                    else:
+                        self.apply_S(qubits)
+                elif oper == 'LC':
+                    if not hermitian:
+                        self.apply_sqrt_minIX(qubits)
+                    else:
+                        self.apply_Z(qubits)
+                        self.apply_K(qubits)
+                else:
+                    pass
+            if hermitian: seq_oper = seq_oper[::-1]
+            if return_seq:
+                return seq_oper
+        else:
+            return seq_oper
 
     def find_SQC_equiv_graph_state(self,return_operations = False):
         """

--- a/toolbox/stabilizerStates.py
+++ b/toolbox/stabilizerStates.py
@@ -46,7 +46,7 @@ class StabilizerState:
                 A binary array representing the generators of the stabilizer group.
                 If the array is n-by-2n a stabilizer state on n qubits will be represented.
                 The n first columns are the X-stabilizers and the n last the Z-stabilizer.
-                If the array is n-by-(2n+1), the last column are seen as the phase for each generator
+                If the array is n-by-(2n+1), the last column is seen as the phase for each generator
                 as follows:
                     0 -> 1
                     1 -> -1


### PR DESCRIPTION
- Added _find_SQC_equiv_graph_state_, which returns a graph corresponding to a graph state which can be reached by single qubit Clifford operations from the input stabilizer state.
- Added option in _find_SQC_equiv_graph_state_ to also return the needed SQC operations
- Added tests for this new method