### PR TITLE
Fixed ResourceWarning in test_context and made the numpy requirement …

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+numpy>=1.14.0,<1.15.0
 scipy>=1.1.0
 Cython>=0.28.5
 service_identity>=17.0.0

--- a/tests/auto/pythonLib/test_context.py
+++ b/tests/auto/pythonLib/test_context.py
@@ -5,20 +5,21 @@ from SimulaQron.settings import Settings
 
 class TestContext(unittest.TestCase):
     def setUp(self):
-        self.qubits = []
+        self.cqcs = []
 
     def tearDown(self):
-        for q in self.qubits:
-            q.measure()
+        for cqc in self.cqcs:
+            cqc.close()
 
     def test_without_context(self):
         for _ in range(Settings.CONF_MAXQUBITS):
             cqc = CQCConnection("Alice")
-            self.qubits.append(qubit(cqc))
+            self.cqcs.append(cqc)
+            qubit(cqc)
         with self.assertRaises(CQCNoQubitError):
             cqc = CQCConnection("Alice")
+            self.cqcs.append(cqc)
             qubit(cqc)
-        cqc.close()
 
     def test_with_context(self):
         for _ in range(Settings.CONF_MAXQUBITS):


### PR DESCRIPTION
…to be <1.15.0 to avoid PendingDeprecationWarning of numpy.matrix