### PR TITLE
118 notify headers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ lint:
 	@${PYTHON} -m flake8 ${CQC_DIR} ${EXAMPLES_DIR} ${GENERAL_DIR} ${LOCAL_DIR} ${RUN_DIR} ${TESTS_DIR} ${TOOLBOX_DIR} ${VIRTNODE_DIR}
 
 python-deps:
-	@$(PIP) install -r requirements.txt
+	@cat requirements.txt | xargs -n 1 -L 1 $(PIP) install
 
 tests:
 	@sh $(RUN_TESTS) --quick --projectq

--- a/cqc/backend/cqcHeader.py
+++ b/cqc/backend/cqcHeader.py
@@ -132,6 +132,7 @@ class Header(metaclass=abc.ABCMeta):
     def pack(self):
         """
             Pack data into packet format.
+
         :return: bytes
         """
         if not self.is_set:

--- a/cqc/backend/cqcHeader.py
+++ b/cqc/backend/cqcHeader.py
@@ -946,8 +946,11 @@ class CQCEPRRequestHeader(Header):
         "float:32=max_time, "
         "uint:16=remote_port, "
         "uint:8=num_pairs, "
-        "uint:4=priority",
-        "uint:1=store, " "uint:1=atomic, " "uint:1=measure_directly, " "uint:2=0",
+        "uint:4=priority, "
+        "uint:1=store, "
+        "uint:1=atomic, "
+        "uint:1=measure_directly, "
+        "uint:1=0"
     )
 
     HDR_LENGTH = CQC_EPR_REQ_LENGTH

--- a/cqc/backend/cqcHeader.py
+++ b/cqc/backend/cqcHeader.py
@@ -947,7 +947,7 @@ class CQCEPRRequestHeader(Header):
         "uint:16=remote_port, "
         "uint:8=num_pairs, "
         "uint:4=priority",
-        "uint:1=store, " "uint:1=measure_directly, " "uint:2=0",
+        "uint:1=store, " "uint:1=atomic, " "uint:1=measure_directly, " "uint:2=0",
     )
 
     HDR_LENGTH = CQC_EPR_REQ_LENGTH
@@ -966,13 +966,15 @@ class CQCEPRRequestHeader(Header):
             self.max_time = 0.0
             self.priority = 0
             self.store = True
+            self.atomic = False
             self.measure_directly = False
 
             self.is_set = False
         else:
             self.unpack(headerBytes)
 
-    def setVals(self, remote_ip, remote_port, num_pairs, min_fidelity, max_time, priority, store, measure_directly):
+    def setVals(self, remote_ip, remote_port, num_pairs, min_fidelity, max_time, priority, store, atomic,
+                measure_directly):
         """
         Stores required parameters of Entanglement Generation Protocol Request
 
@@ -1002,6 +1004,7 @@ class CQCEPRRequestHeader(Header):
         self.max_time = max_time
         self.priority = priority
         self.store = store
+        self.atomic = atomic
         self.measure_directly = measure_directly
 
         self.is_set = True
@@ -1022,6 +1025,7 @@ class CQCEPRRequestHeader(Header):
             "num_pairs": self.num_pairs,
             "priority": self.priority,
             "store": self.store,
+            "atomic": self.atomic,
             "measure_directly": self.measure_directly,
         }
         request_Bitstring = bitstring.pack(self.package_format, **to_pack)
@@ -1044,7 +1048,8 @@ class CQCEPRRequestHeader(Header):
         self.num_pairs = request_fields[4]
         self.priority = request_fields[5]
         self.store = request_fields[6]
-        self.measure_directly = request_fields[7]
+        self.atomic = request_fields[7]
+        self.measure_directly = request_fields[8]
 
         self.is_set = True
 
@@ -1064,6 +1069,7 @@ class CQCEPRRequestHeader(Header):
             to_print += "Num Pairs: {}".format(self.num_pairs)
             to_print += "Priority: {}".format(self.priority)
             to_print += "Store: {}".format(self.store)
+            to_print += "Atomic: {}".format(self.atomic)
             to_print += "Measure Directly: {}".format(self.measure_directly)
 
             return to_print

--- a/cqc/backend/cqcHeader.py
+++ b/cqc/backend/cqcHeader.py
@@ -531,7 +531,7 @@ class CQCCommunicationHeader:
     packaging_format_v1 = "!HLH"
     HDR_LENGTH = CQC_COM_HDR_LENGTH
 
-    def __init__(self, headerBytes=None):
+    def __init__(self, headerBytes=None, cqc_version=CQC_VERSION):
         """
         Initialize from packet data
         :param headerBytes:  packet data
@@ -543,7 +543,7 @@ class CQCCommunicationHeader:
             self.remote_node = 0
 
         else:
-            self.unpack(headerBytes)
+            self.unpack(headerBytes, cqc_version=cqc_version)
 
     def setVals(self, remote_app_id, remote_node, remote_port):
         """

--- a/cqc/backend/cqcLogMessageHandler.py
+++ b/cqc/backend/cqcLogMessageHandler.py
@@ -29,6 +29,7 @@
 """
 This class interfaces cqcMessageHandler, and is for testing purposes only
 """
+
 import logging
 
 from SimulaQron.cqc.backend.cqcMessageHandler import CQCMessageHandler
@@ -97,7 +98,7 @@ class CQCLogMessageHandler(CQCMessageHandler):
         if len(data) >= cmd_l:
             subdata["cmd_header"] = cls.parse_cmd(CQCCmdHeader(data[:cmd_l]))
         if len(data) >= cmd_l + xtra_l:
-            subdata["xtra_header"] = cls.parse_xtra(CQCXtraHeader(data[cmd_l : cmd_l + xtra_l]))
+            subdata["xtra_header"] = cls.parse_xtra(CQCXtraHeader(data[cmd_l: cmd_l + xtra_l]))
         cls.logData.append(subdata)
         with open(cls.file, "w") as outfile:
             json.dump(cls.logData, outfile)
@@ -268,7 +269,8 @@ class CQCLogMessageHandler(CQCMessageHandler):
             length = CQC_NOTIFY_LENGTH
         else:
             length = CQC_MEAS_OUT_HDR_LENGTH
-        cqc_msg = self.create_return_message(cqc_header.app_id, CQC_TP_MEASOUT, length=length, cqc_version=cqc_header.version)
+        cqc_msg = self.create_return_message(cqc_header.app_id, CQC_TP_MEASOUT, length=length,
+                                             cqc_version=cqc_header.version)
 
         outcome = 2
         if cqc_header.version < 2:
@@ -288,7 +290,8 @@ class CQCLogMessageHandler(CQCMessageHandler):
             length = CQC_NOTIFY_LENGTH
         else:
             length = CQC_MEAS_OUT_HDR_LENGTH
-        cqc_msg = self.create_return_message(cqc_header.app_id, CQC_TP_MEASOUT, length=length, cqc_version=cqc_header.version)
+        cqc_msg = self.create_return_message(cqc_header.app_id, CQC_TP_MEASOUT, length=length,
+                                             cqc_version=cqc_header.version)
 
         outcome = 2
         if cqc_header.version < 2:
@@ -316,7 +319,8 @@ class CQCLogMessageHandler(CQCMessageHandler):
             length = CQC_NOTIFY_LENGTH
         else:
             length = CQC_XTRA_QUBIT_HDR_LENGTH
-        recv_msg = self.create_return_message(cqc_header.app_id, CQC_TP_RECV, length=length, cqc_version=cqc_header.version)
+        recv_msg = self.create_return_message(cqc_header.app_id, CQC_TP_RECV, length=length,
+                                              cqc_version=cqc_header.version)
 
         if cqc_header.version < 2:
             hdr = CQCNotifyHeader()
@@ -386,7 +390,6 @@ class CQCLogMessageHandler(CQCMessageHandler):
         msg = hdr.pack()
         self.return_messages.append(msg)
 
-
         # Send entanglement info
         ent_id = 1
         ent_info = EntInfoHeader()
@@ -417,7 +420,8 @@ class CQCLogMessageHandler(CQCMessageHandler):
             length = CQC_NOTIFY_LENGTH
         else:
             length = CQC_XTRA_QUBIT_HDR_LENGTH
-        cqc_msg = self.create_return_message(cqc_header.app_id, CQC_TP_RECV, length=length, cqc_version=cqc_header.version)
+        cqc_msg = self.create_return_message(cqc_header.app_id, CQC_TP_RECV, length=length,
+                                             cqc_version=cqc_header.version)
 
         if cqc_header.version < 2:
             hdr = CQCNotifyHeader()
@@ -440,7 +444,8 @@ class CQCLogMessageHandler(CQCMessageHandler):
                 length = CQC_NOTIFY_LENGTH
             else:
                 length = CQC_XTRA_QUBIT_HDR_LENGTH
-            cqc_msg = self.create_return_message(cqc_header.app_id, CQC_TP_NEW_OK, length=length, cqc_version=cqc_header.version)
+            cqc_msg = self.create_return_message(cqc_header.app_id, CQC_TP_NEW_OK, length=length,
+                                                 cqc_version=cqc_header.version)
             self.return_messages.append(cqc_msg)
 
             if cqc_header.version < 2:

--- a/cqc/backend/cqcMessageHandler.py
+++ b/cqc/backend/cqcMessageHandler.py
@@ -836,7 +836,7 @@ class SimulaqronCQCHandler(CQCMessageHandler):
             hdr.setVals(cmd.qubit_id, outcome, 0, 0, 0, 0)
         else:
             hdr = CQCMeasOutHeader()
-            hdr.setVals(meas_out=outcome)
+            hdr.setVals(outcome=outcome)
         msg = hdr.pack()
         self.return_messages.append(msg)
         # self.protocol.transport.write(msg)

--- a/cqc/backend/entInfoHeader.py
+++ b/cqc/backend/entInfoHeader.py
@@ -32,17 +32,23 @@ import logging
 import struct
 import bitstring
 
+from SimulaQron.cqc.backend.cqcHeader import Header
+
 # Lengths of the headers in bytes
-ENT_INFO_LENGTH = 40  # Length of a entanglement information header
+ENT_INFO_LENGTH = 40                 # Length of a entanglement information header
+ENT_INFO_CREATE_KEEP_LENGTH = 28     # Length of a entanglement information header (for create and keep)
+ENT_INFO_MEAS_DIRECT_LENGTH = 24     # Length of a entanglement information header (for measure directly)
 
 ENT_INFO_TP_CREATE_KEEP = 1  # Type of message when entanglement is kept
 ENT_INFO_TP_MEAS_DIRECT = 2  # Type of message when entanglement is measured directly (for classical correlations)
 
 
-class EntInfoHeader:
+class EntInfoHeader(Header):
     """
     Header for a entanglement information packet. Fo
     """
+
+    HDR_LENGTH = ENT_INFO_LENGTH
 
     def __init__(self, headerBytes=None):
         """
@@ -186,7 +192,7 @@ class EntInfoHeader:
             self.DF = DF
 
 
-class EntInfoCreateKeepHeader:
+class EntInfoCreateKeepHeader(Header):
     """
         Header for a entanglement information packet, where entanglement is kept after generation
     """
@@ -206,6 +212,8 @@ class EntInfoCreateKeepHeader:
         "float:32=goodness, "
         "uint:32=create_id"
     )
+
+    HDR_LENGTH = ENT_INFO_CREATE_KEEP_LENGTH
 
     def __init__(self, headerBytes=None):
         """
@@ -346,7 +354,7 @@ class EntInfoCreateKeepHeader:
             self.DF = DF
 
 
-class EntInfoMeasDirectHeader:
+class EntInfoMeasDirectHeader(Header):
     """
         Header for a entanglement information packet, where communication qubit is measured directly after emission.
     """
@@ -367,6 +375,8 @@ class EntInfoMeasDirectHeader:
         "float:32=goodness, "
         "uint:32=create_id"
     )
+
+    HDR_LENGTH = ENT_INFO_MEAS_DIRECT_LENGTH
 
     def __init__(self, headerBytes=None):
         """

--- a/cqc/pythonLib/cqc.py
+++ b/cqc/pythonLib/cqc.py
@@ -901,6 +901,7 @@ class CQCConnection:
         """
         parses the cqc message and returns the relevant value of that measure
         (qubit, measurement outcome)
+
         :param message: str
             the cqc message to be parsed
         :param q: :obj:`SimulaQron.cqc.pythonLib.cqc.qubit`

--- a/cqc/pythonLib/cqc.py
+++ b/cqc/pythonLib/cqc.py
@@ -38,6 +38,7 @@ import struct
 
 from SimulaQron.cqc.backend.cqcConfig import CQC_CONF_LINK_WAIT_TIME, CQC_CONF_COM_WAIT_TIME
 from SimulaQron.cqc.backend.cqcHeader import (
+    Header,
     CQCCmdHeader,
     CQC_CMD_SEND,
     CQC_CMD_EPR,
@@ -82,6 +83,10 @@ from SimulaQron.cqc.backend.cqcHeader import (
     CQC_NOTIFY_LENGTH,
     CQC_ERR_NOQUBIT,
     CQCNotifyHeader,
+    CQCMeasOutHeader,
+    CQC_MEAS_OUT_HDR_LENGTH,
+    CQCTimeinfoHeader,
+    CQC_TIMEINFO_HDR_LENGTH,
     CQC_TP_MEASOUT,
     CQC_ERR_TIMEOUT,
     CQC_TP_RECV,
@@ -819,49 +824,58 @@ class CQCConnection:
                 continue
             else:
                 break
-                # We got all the data, read notify (and ent_info) if there is any
+                # We got all the data, read other headers if there is any
         if currHeader.length == 0:
             return currHeader, None, None
-        elif currHeader.length == CQC_NOTIFY_LENGTH:
-            try:
-                rawNotifyHeader = self.buf[:CQC_NOTIFY_LENGTH]
-                self.buf = self.buf[CQC_NOTIFY_LENGTH : len(self.buf)]
-                notifyHeader = CQCNotifyHeader(rawNotifyHeader)
-                return currHeader, notifyHeader, None
-            except struct.error as err:
-                print(err)
-        elif currHeader.length == CQC_NOTIFY_LENGTH + ENT_INFO_LENGTH:
-            try:
-                rawNotifyHeader = self.buf[:CQC_NOTIFY_LENGTH]
-                self.buf = self.buf[CQC_NOTIFY_LENGTH : len(self.buf)]
-                notifyHeader = CQCNotifyHeader(rawNotifyHeader)
-
-                rawEntInfoHeader = self.buf[:ENT_INFO_LENGTH]
-                self.buf = self.buf[ENT_INFO_LENGTH : len(self.buf)]
-                entInfoHeader = EntInfoHeader(rawEntInfoHeader)
-
-                return currHeader, notifyHeader, entInfoHeader
-            except struct.error as err:
-                print(err)
         else:
-            logging.warning("Warning: Received message of unknown length, return None")
+            if currHeader.tp == CQC_TP_INF_TIME:
+                timeinfo_header = self._extract_header(CQCTimeinfoHeader)
+                return currHeader, timeinfo_header, None
+            elif currHeader.tp == CQC_TP_MEASOUT:
+                measout_header = self._extract_header(CQCMeasOutHeader)
+                return currHeader, measout_header, None
+            elif currHeader.tp in [CQC_TP_RECV, CQC_TP_NEW_OK, CQC_TP_EXPIRE]:
+                xtra_qubit_header = self._extract_header(CQCXtraQubitHeader)
+                return currHeader, xtra_qubit_header, None
+            elif currHeader.tp == CQC_TP_EPR_OK:
+                xtra_qubit_header = self._extract_header(CQCXtraQubitHeader)
+                ent_info_hdr = self._extract_header(EntInfoHeader)
+                return currHeader, xtra_qubit_header, ent_info_hdr
+
+    def _extract_header(self, header_class):
+        """
+        Extracts the given header class from the first part of the current buffer.
+        :param header_class: Subclassed from `SimulaQron.cqc.backend.cqcHeader.Header`
+        :return: An instance of the class
+        """
+        if not issubclass(header_class, Header):
+            raise ValueError("header_class {} is not a subclass of Header".format(header_class))
+
+        try:
+            rawHeader = self.buf[:header_class.HDR_LENGTH]
+        except IndexError:
+            raise ValueError("Got a header message of unexpected size")
+        self.buf = self.buf[header_class.HDR_LENGTH: len(self.buf)]
+        header = header_class(rawHeader)
+
+        return header
 
     def print_CQC_msg(self, message):
         """
         Prints messsage returned by the readMessage method of CQCConnection.
         """
         hdr = message[0]
-        notifyHdr = message[1]
+        otherHdr = message[1]
         entInfoHdr = message[2]
 
         if hdr.tp == CQC_TP_HELLO:
             logging.debug("CQC tells App {}: 'HELLO'".format(self.name))
         elif hdr.tp == CQC_TP_EXPIRE:
-            logging.debug("CQC tells App {}: 'Qubit with ID {} has expired'".format(self.name, notifyHdr.qubit_id))
+            logging.debug("CQC tells App {}: 'Qubit with ID {} has expired'".format(self.name, otherHdr.qubit_id))
         elif hdr.tp == CQC_TP_DONE:
             logging.debug("CQC tells App {}: 'Done with command'".format(self.name))
         elif hdr.tp == CQC_TP_RECV:
-            logging.debug("CQC tells App {}: 'Received qubit with ID {}'".format(self.name, notifyHdr.qubit_id))
+            logging.debug("CQC tells App {}: 'Received qubit with ID {}'".format(self.name, otherHdr.qubit_id))
         elif hdr.tp == CQC_TP_EPR_OK:
 
             # Lookup host name
@@ -880,13 +894,13 @@ class CQCConnection:
 
             logging.debug(
                 "CQC tells App {}: 'EPR created with node {}, using qubit with ID {}'".format(
-                    self.name, remote_name, notifyHdr.qubit_id
+                    self.name, remote_name, otherHdr.qubit_id
                 )
             )
         elif hdr.tp == CQC_TP_MEASOUT:
-            logging.debug("CQC tells App {}: 'Measurement outcome is {}'".format(self.name, notifyHdr.outcome))
+            logging.debug("CQC tells App {}: 'Measurement outcome is {}'".format(self.name, otherHdr.outcome))
         elif hdr.tp == CQC_TP_INF_TIME:
-            logging.debug("CQC tells App {}: 'Timestamp is {}'".format(self.name, notifyHdr.datetime))
+            logging.debug("CQC tells App {}: 'Timestamp is {}'".format(self.name, otherHdr.datetime))
 
     def parse_CQC_msg(self, message, q=None, is_factory=False):
         """
@@ -1016,8 +1030,8 @@ class CQCConnection:
 
             # Get RECV message
             message = self.readMessage()
-            notifyHdr = message[1]
-            q_id = notifyHdr.qubit_id
+            otherHdr = message[1]
+            q_id = otherHdr.qubit_id
 
             self.print_CQC_msg(message)
 
@@ -1077,9 +1091,9 @@ class CQCConnection:
             )
             # Get RECV message
             message = self.readMessage()
-            notifyHdr = message[1]
+            otherHdr = message[1]
             entInfoHdr = message[2]
-            q_id = notifyHdr.qubit_id
+            q_id = otherHdr.qubit_id
 
             self.print_CQC_msg(message)
 
@@ -1117,9 +1131,9 @@ class CQCConnection:
 
             # Get RECV message
             message = self.readMessage()
-            notifyHdr = message[1]
+            otherHdr = message[1]
             entInfoHdr = message[2]
-            q_id = notifyHdr.qubit_id
+            q_id = otherHdr.qubit_id
 
             self.print_CQC_msg(message)
 
@@ -1471,8 +1485,8 @@ class qubit:
                 # Get qubit id
                 message = self._cqc.readMessage()
                 try:
-                    notifyHdr = message[1]
-                    self._qID = notifyHdr.qubit_id
+                    otherHdr = message[1]
+                    self._qID = otherHdr.qubit_id
                 except AttributeError:
                     raise CQCGeneralError("Didn't receive the qubit id")
                     # Activate qubit
@@ -1848,8 +1862,8 @@ class qubit:
             if not inplace:
                 self._set_active(False)
             try:
-                notifyHdr = message[1]
-                return notifyHdr.outcome
+                otherHdr = message[1]
+                return otherHdr.outcome
             except AttributeError:
                 return None
 
@@ -1909,7 +1923,7 @@ class qubit:
         # Return time-stamp
         message = self._cqc.readMessage()
         try:
-            notifyHdr = message[1]
-            return notifyHdr.datetime
+            otherHdr = message[1]
+            return otherHdr.datetime
         except AttributeError:
             return None

--- a/cqc/pythonLib/cqc.py
+++ b/cqc/pythonLib/cqc.py
@@ -34,7 +34,6 @@ import time
 import logging
 import socket
 import warnings
-import struct
 
 from SimulaQron.cqc.backend.cqcConfig import CQC_CONF_LINK_WAIT_TIME, CQC_CONF_COM_WAIT_TIME
 from SimulaQron.cqc.backend.cqcHeader import (
@@ -80,13 +79,9 @@ from SimulaQron.cqc.backend.cqcHeader import (
     CQCFactoryHeader,
     CQC_CMD_HDR_LENGTH,
     CQC_TP_INF_TIME,
-    CQC_NOTIFY_LENGTH,
     CQC_ERR_NOQUBIT,
-    CQCNotifyHeader,
     CQCMeasOutHeader,
-    CQC_MEAS_OUT_HDR_LENGTH,
     CQCTimeinfoHeader,
-    CQC_TIMEINFO_HDR_LENGTH,
     CQC_TP_MEASOUT,
     CQC_ERR_TIMEOUT,
     CQC_TP_RECV,
@@ -94,7 +89,7 @@ from SimulaQron.cqc.backend.cqcHeader import (
     CQC_TP_NEW_OK,
     CQC_TP_EXPIRE,
 )
-from SimulaQron.cqc.backend.entInfoHeader import EntInfoHeader, ENT_INFO_LENGTH
+from SimulaQron.cqc.backend.entInfoHeader import EntInfoHeader
 from SimulaQron.general.hostConfig import cqc_node_id_from_addrinfo, networkConfig
 from SimulaQron.settings import Settings
 

--- a/run/startAllLog.sh
+++ b/run/startAllLog.sh
@@ -16,7 +16,7 @@ then
         python "$NETSIM/configFiles.py" --nd "Alice Bob Charlie David Eve"
 
         # We call this script again, without arguments, to use the newly created config-files
-        sh "$NETSIM/run/startAll.sh"
+        sh "$NETSIM/run/startAllLog.sh"
     fi
 else  # if arguments were given, create the new nodes and start them
     while [ "$#" -gt 0 ]; do


### PR DESCRIPTION
The CQCNotifyHeader is now split up into CQCXtraQubitHeader, CQCMeasOurHeader and CQCTimeinfoHeader. The CQC version is now changed to 2, however earlier versions are still supported.

Also changed how Python package requirements are checked and installed.

fixes #118 