### PR TITLE
Command to install Python Dependencies

### DIFF
--- a/docs/GettingStarted.rst
+++ b/docs/GettingStarted.rst
@@ -41,9 +41,9 @@ you use bash (e.g., standard on OSX or the GIT Bash install on Windows 10), othe
 
 where yourPath is the directory containing SimulaQron. You can add this to your ~/.bashrc or ~/.bash_profile file.
 
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Verifying the installation
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Verifying the installation and dependencies
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 To run SimulaQron you need to following Python packages:
 
@@ -56,6 +56,10 @@ To run SimulaQron you need to following Python packages:
 * networkx
 * projectq
 * bitstring
+
+To install the dependencies, type::
+
+    make python-deps
 
 To verify that that SimulaQron is working on your computer, type::
 


### PR DESCRIPTION
The easiest way to install the dependencies for SimulaQron is:
`pip install -r requirements.txt`

However, if we are doing a fresh installation (without any dependecies beforehand, like in virtualenv) this will break the process because Qutip depends on Cython and hence the pip installation will fail. Using the command `make verify` will also not work because the target `verify` invokes the recipe target `lint` before `python-deps`, which will return an error if flake8 module is not installed. 

Hence, in order to make the installation process easier for a beginner, I thought we should write the already available target `python-deps` into the docs.