### PR TITLE
Ref issue #180 Add explicit error messages

### DIFF
--- a/simulaqron/SimulaQron.py
+++ b/simulaqron/SimulaQron.py
@@ -145,7 +145,11 @@ def start(name, nrnodes, nodes, topology, force, keep):
                 print("Aborted!")
                 return
     d = SimulaQronDaemon(pidfile=pidfile, name=name, nrnodes=nrnodes, nodes=nodes, topology=topology, new=new)
-    d.start()
+    try:
+        d.start()
+    except SystemExit:
+        logging.debug("pidfile: {}".format(pidfile))
+        print("Failed to launch SimulaQron Daemon. Aborted!")
 
 ###############
 # stop command #


### PR DESCRIPTION
Provide users with explicit messages when users failed to start the daemon. It will greatly help users figure out what's going on sooner.

When the daemon, which inherits `run.RunDaemon` failed to start, it will raise `SystemExit` at the end. This code snippet will catch it. One of the user case could be referred to Issue #180 .