### PR TITLE
Ref issue #180 Add explicit error messages

### DIFF
--- a/simulaqron/SimulaQron.py
+++ b/simulaqron/SimulaQron.py
@@ -4,6 +4,7 @@ import time
 import click
 import logging
 from daemons.prefab import run
+from daemons.interfaces import exit
 
 import simulaqron
 from simulaqron.network import Network
@@ -145,7 +146,14 @@ def start(name, nrnodes, nodes, topology, force, keep):
                 print("Aborted!")
                 return
     d = SimulaQronDaemon(pidfile=pidfile, name=name, nrnodes=nrnodes, nodes=nodes, topology=topology, new=new)
-    d.start()
+    try:
+        d.start()
+    except SystemExit as e:
+        if e.code == exit.PIDFILE_INACCESSIBLE or\
+           e.code == exit.DAEMONIZE_FAILED:
+            logging.debug("Failed to launch Simulaqron Daemon. "
+                          "Exit code reported by daemons: {}".format(e.code))
+            print("Failed to launch SimulaQron Daemon. Aborted!")
 
 ###############
 # stop command #


### PR DESCRIPTION
Provide users with explicit messages when users failed to start the daemon. It will greatly help users figure out what's going on sooner rather than a silent failure.

When the daemon, which inherits `run.RunDaemon` failed to start, it will raise `SystemExit` and the corresponding exit code at the end. This code snippet will catch it. One of the user case could be referred to Issue #180 .

This pull request is an improvement version for https://github.com/SoftwareQuTech/SimulaQron/pull/181