### PR TITLE
Add Travis CI build status badge of Develop branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Build Status](https://travis-ci.org/SoftwareQuTech/SimulaQron.svg?branch=Develop)](https://travis-ci.org/SoftwareQuTech/SimulaQron)
 
 SimulaQron - simple quantum network simulator
 =============================================


### PR DESCRIPTION
This pull request will add a typical Travis CI build status badge of *Develop* branch.

The development of SimulaQron is in `Develop` branch rather than `master` so it makes much sense for me to show the status of `Develop` branch.

Please note the corresponding Travis CI build of `Develop` branch of `SimulaQron` repository owned by `SoftwareQuTech` should be activated to show the badge correctly.