### PR TITLE
Fixed bug in the stabilizer formalism which can occur when measuring …

### DIFF
--- a/simulaqron/tests/unittests/quick/stabilizerStates/test_stabilizerStates.py
+++ b/simulaqron/tests/unittests/quick/stabilizerStates/test_stabilizerStates.py
@@ -77,7 +77,7 @@ class TestStabilizerStates(unittest.TestCase):
         self.assertTrue(s1 == phim)
 
         # Test faulty input
-        data = ["XX", "-1ZZ"]
+        data = ["XX", "-2ZZ"]
         with self.assertRaises(ValueError):
             StabilizerState(data)
 
@@ -368,6 +368,39 @@ class TestStabilizerStates(unittest.TestCase):
         GHZ_graph, operations = GHZ.find_SQC_equiv_graph_state(return_operations=True)
         self.assertTrue(GHZ_graph, nx.star_graph(n - 1))
         self.assertTrue(operations == [("H", i) for i in range(1, n)])
+
+    def test_contains(self):
+        tests = [  # stabilizer, expected
+            ("XX", True),
+            ("+1XX", True),
+            ("-1XX", False),
+            ("+1YY", False),
+            ("-1YY", True),
+            ("+1YI", False),
+            ("IY", False),
+        ]
+
+        for stabilizer, expected in tests:
+            with self.subTest(stabilizer=stabilizer, expected=expected):
+                s = StabilizerState(["XX", "ZZ"])
+                output = s.contains(stabilizer)
+                self.assertEqual(output, expected)
+
+    def test_measure_eigenstate(self):
+        tests = [  # stabilizers, qubit, expected
+            (["ZI", "IZ"], 0, 0),
+            (["-1ZI", "IZ"], 0, 1),
+            (["ZI", "ZZ"], 0, 0),
+            (["IZ", "-1ZZ"], 0, 1),
+            (["IZ", "-1ZI"], 0, 1),
+            (["+1XIIII", "+1IXIII", "+1IIXII", "-1IIIZI", "+1IIIZZ"], 4, 1),
+        ]
+
+        for stabilizers, qubit, expected in tests:
+            with self.subTest(stabilizers=stabilizers, qubit=qubit, expected=expected):
+                s = StabilizerState(stabilizers)
+                output = s.measure(qubit)
+                self.assertEqual(output, expected)
 
 
 if __name__ == "__main__":

--- a/simulaqron/toolbox/stabilizerStates.py
+++ b/simulaqron/toolbox/stabilizerStates.py
@@ -294,8 +294,13 @@ class StabilizerState:
                 for i_loop in non_zero_except_i_max:
                     extra_phase = 0  # we count i's here, so 2 -> (-i)^2=-1, 4->1, 6-> -1
                     for j in range(num_paulis):
-                        extra_phase += StabilizerState.Pauli_phase_tracking(
-                            [new_matrix[i_loop, j], new_matrix[i_loop, j + num_paulis]], [new_matrix[h, j], new_matrix[h, j + num_paulis]]
+                        extra_phase += StabilizerState.Pauli_phase_tracking([
+                            new_matrix[i_loop, j],
+                            new_matrix[i_loop, j + num_paulis]
+                        ], [
+                            new_matrix[h, j],
+                            new_matrix[h, j + num_paulis]
+                        ]
                         )
                     new_matrix[i_loop, :] = np.logical_xor(new_matrix[i_loop, :], new_matrix[h, :])
                     # NOTE we are assuming that -I is not in the group and therefore that no stabilizer element


### PR DESCRIPTION
Fixed bug in the stabilizer formalism which can occur when measuring a qubit in an eigenstate of Z. This was because whether the state was |0> or |1> was not checked in the correct way.

Also added tests that catch this bug.