### PR TITLE
[242] show info about pidfile when network is considered running

### DIFF
--- a/simulaqron/SimulaQron.py
+++ b/simulaqron/SimulaQron.py
@@ -136,6 +136,7 @@ def start(name, nrnodes, nodes, topology, force, keep):
     pidfile = os.path.join(PID_FOLDER, "simulaqron_network_{}.pid".format(name))
     if os.path.exists(pidfile):
         logging.warning("Network with name {} is already running".format(name))
+        logging.warning("The pidfile for this network is located at {}".format(pidfile))
         return
     if new:
         if not force:


### PR DESCRIPTION
However, when simulaqron is terminated in a non-normal way, that
pidfile will not be removed. This fix tells the user where the pidfile
is, so he can remove it in case he's sure the network is not running.
Fixes #242